### PR TITLE
Resolução alternativa para o requisito 5

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ export default function App() {
       <BrowserRouter>
         <Switch>
           <Route exact path="/" component={ Login } />
-          <Route path="/Trivia" component={ Trivia } />
+          <Route path="/trivia" component={ Trivia } />
           <Route path="/settings" component={ Settings } />
         </Switch>
       </BrowserRouter>

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { fetchQuestions } from '../redux/actions';
 import getApiToken from '../services/ApiRequest';
 
 class Login extends Component {
@@ -10,8 +11,8 @@ class Login extends Component {
       name: '',
       email: '',
     };
-    this.handleClickTrivia = this.handleClickTrivia.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleClickTrivia = this.handleClickTrivia.bind(this);
     this.handleClickSettings = this.handleClickSettings.bind(this);
   }
 
@@ -22,8 +23,11 @@ class Login extends Component {
   }
 
   async handleClickTrivia() {
-    const getResultsFromAPI = await getApiToken();
-    localStorage.setItem('token', JSON.stringify(getResultsFromAPI.token));
+    const { history, dispatchFetchQuestions } = this.props;
+    const { token } = await getApiToken();
+    localStorage.setItem('token', token);
+    dispatchFetchQuestions();
+    history.push('/trivia');
   }
 
   handleClickSettings() {
@@ -54,19 +58,10 @@ class Login extends Component {
             onChange={ this.handleChange }
           />
         </label>
-        <Link to="/Trivia">
-          <button
-            data-testid="btn-play"
-            type="button"
-            onClick={ this.handleClickTrivia }
-            disabled={ disabled }
-          >
-            Jogar
-          </button>
-        </Link>
         <button
           data-testid="btn-play"
           type="button"
+          onClick={ this.handleClickTrivia }
           disabled={ disabled }
         >
           Jogar
@@ -83,8 +78,14 @@ class Login extends Component {
   }
 }
 
+function mapDispatchToProps(dispatch) {
+  return {
+    dispatchFetchQuestions: () => dispatch(fetchQuestions()),
+  };
+}
+
+export default connect(null, mapDispatchToProps)(Login);
+
 Login.propTypes = {
   history: PropTypes.objectOf(PropTypes.any).isRequired,
 };
-
-export default Login;

--- a/src/pages/Trivia.jsx
+++ b/src/pages/Trivia.jsx
@@ -1,9 +1,23 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-export default class Trivia extends Component {
+export class Trivia extends Component {
   render() {
+    const { gameState: { isFetching, questions } } = this.props;
+    console.log(questions);
+
     return (
-      <div />
+      isFetching
+        ? <h2>Carregando...</h2>
+        : questions.map(({ question }, index) => <p key={ index }>{question}</p>)
     );
   }
 }
+
+function mapStateToProps(state) {
+  return {
+    gameState: state.game,
+  };
+}
+
+export default connect(mapStateToProps)(Trivia);

--- a/src/redux/actions/index.js
+++ b/src/redux/actions/index.js
@@ -1,0 +1,28 @@
+import { getApiTrivia } from '../../services/ApiRequest';
+
+export const REQUEST_QUESTIONS = 'REQUEST_QUESTIONS';
+export const GET_QUESTIONS = 'GET_QUESTIONS';
+
+function requestQuestions() {
+  return { type: REQUEST_QUESTIONS };
+}
+
+function getQuestions(questions) {
+  return { type: GET_QUESTIONS, payload: questions };
+}
+
+function decodeQuestion(questionData) {
+  const { question } = questionData;
+  const decodedQuestion = atob(question);
+
+  return { ...questionData, question: decodedQuestion };
+}
+
+export function fetchQuestions() {
+  return async (dispatch) => {
+    dispatch(requestQuestions());
+    const token = localStorage.getItem('token');
+    const { results } = await getApiTrivia(token);
+    dispatch(getQuestions(results.map((questionData) => decodeQuestion(questionData))));
+  };
+}

--- a/src/redux/reducers/game.js
+++ b/src/redux/reducers/game.js
@@ -1,0 +1,17 @@
+import { REQUEST_QUESTIONS, GET_QUESTIONS } from '../actions';
+
+const INITIAL_STATE = {
+  isFetching: false,
+  questions: [],
+};
+
+export default function game(state = INITIAL_STATE, action) {
+  switch (action.type) {
+  case REQUEST_QUESTIONS:
+    return { ...state, isFetching: true };
+  case GET_QUESTIONS:
+    return { ...state, isFetching: false, questions: [...action.payload] };
+  default:
+    return state;
+  }
+}

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import playerReducer from './player';
+import game from './game';
 
-const rootReducer = combineReducers({ playerReducer });
+const rootReducer = combineReducers({ playerReducer, game });
 
 export default rootReducer;

--- a/src/services/ApiRequest.js
+++ b/src/services/ApiRequest.js
@@ -7,3 +7,10 @@ const getApiToken = async () => {
 };
 
 export default getApiToken;
+
+export const getApiTrivia = async (token) => {
+  const getFetch = await fetch(`https://opentdb.com/api.php?amount=5&encode=base64&token=${token}`);
+  const getJson = await getFetch.json();
+  const getResults = await getJson;
+  return getResults;
+};


### PR DESCRIPTION
**Todo:**
- [ ] Implentar interação com a API aproveitando as vantagens do thunk
- [ ] Decodificar texto das questões
- [ ] Criar componente de questão
- [ ] Renderizar o componente de questão na tela do jogo

**Mudanças importantes em relação à outra implementação desse requisito:**
- Rota da página do jogo passou de `/Trivia` para `/trivia`
- A action `GET_QUESTIONS` foi separada em duas: `REQUEST_QUESTIONS` e `GET_QUESTIONS`, a fim de facilitar a renderização condicional
- Formato do estado no reducer relacionado às questões passou de `[ ]` para `{ isFetching: false, questions: [ ] }`
- Nome do reducer relacionado às questões passou de `questionsReducer` para `game` (assim fica mais claro o que estamos acessando, por exemplo: `game.isFetching`, ou `game.questions`)
- A requisição das perguntas foi englobada numa função que recebe o `dispatch` do Redux através do thunk, conforme o padrão passado para nós no Course ([dia 15.4](https://app.betrybe.com/course/front-end/gerenciamento-de-estado-com-redux/usando-o-redux-no-react-actions-assincronas/5e038872-db20-44f5-b6d5-ab36b654fff6/conteudos/4024403d-2645-41c3-9916-76f37bb7997f/exemplos-guiados/4c67f17a-9c4f-4067-a702-4b15c4c055b5?use_case=side_bar)), a fim de facilitar o dispatch de mais de uma action
- O endpoint no qual as questões são buscadas foi modificado para solicitar as questões codificadas em base64, a fim de facilitar a decodificação delas (vai ser muito mais fácil explicar isso em ligação :laughing:, mas se vocês quiserem entender essa parte por conta própria, pode ajudar tentar renderizar o texto das questões na página para ver o que acontece, e também dar uma lida na parte da documentação da API que fala sobre "Encoding Types" (não tem link direto pra seção, precisa entrar na [documentação](https://opentdb.com/api_config.php) e procurar com CTRL+F).
